### PR TITLE
fix: check for invalid buffer ids

### DIFF
--- a/lua/monark/monark.lua
+++ b/lua/monark/monark.lua
@@ -45,7 +45,9 @@ local function defer_clear(timeout, buffer)
     timeout,
     0,
     vim.schedule_wrap(function()
-      api.nvim_buf_del_extmark(buffer, ns_id, extmark_id)
+      if vim.fn.bufwinnr(buffer) ~= -1 then
+        api.nvim_buf_del_extmark(buffer, ns_id, extmark_id)
+      end
     end)
   )
 end


### PR DESCRIPTION
attempt at fixing #1
im not familiar at all with this so it may not be the best way to fix it

i tried testing with a clean config and it seems that telescope is the issue, monark doesn't account for the telescope popup changing the mode and gets an invalid buffer id when opening a file